### PR TITLE
trim whitespace and split labs more explicitly in festvox-plugin

### DIFF
--- a/festvox-plugin/src/main/groovy/de/dfki/mary/voicebuilding/tasks/FestvoxLabTask.groovy
+++ b/festvox-plugin/src/main/groovy/de/dfki/mary/voicebuilding/tasks/FestvoxLabTask.groovy
@@ -37,7 +37,8 @@ class FestvoxLabTask extends Copy {
     FestvoxLabTask() {
         include '*.lab'
         filter {
-            it.replaceAll(/\w+$/) {
+            def label = it.trim().split(/\s+/, 3).last()
+            it.trim().replaceAll(label) {
                 mapping[it] ?: it
             }
         }


### PR DESCRIPTION
fixes #58