### PR TITLE
set `mary.base` to ensure logs etc. are created under buildDir

### DIFF
--- a/src/main/groovy/de/dfki/mary/voicebuilding/tasks/MaryInterfaceBatchTask.groovy
+++ b/src/main/groovy/de/dfki/mary/voicebuilding/tasks/MaryInterfaceBatchTask.groovy
@@ -50,6 +50,7 @@ class MaryInterfaceBatchTask extends DefaultTask {
             classpath project.sourceSets.marytts.runtimeClasspath
             main 'marytts.BatchProcessor'
             args batchFile
+            systemProperties << ['mary.base': project.buildDir]
         }
     }
 }


### PR DESCRIPTION
closes #73